### PR TITLE
Ft/videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,10 +271,112 @@ Fetch a user by ID.
 
 ---
 
+## 📌 5. Short Video Feed
+
+All video routes require Firebase authentication. Videos use a direct-to-Firebase Storage flow: create metadata first, upload the binary to the returned signed URL, then mark the upload complete.
+
+### ➡️ POST `/videos`
+Create a video document and receive a signed upload URL.
+
+#### 📥 Request
+```json
+{
+  "caption": "Study tip in 30 seconds",
+  "mimeType": "video/mp4",
+  "visibility": "public"
+}
+```
+
+#### 📤 Response
+```json
+{
+  "video": {
+    "id": "videoId123",
+    "caption": "Study tip in 30 seconds",
+    "status": "uploading",
+    "visibility": "public",
+    "likeCount": 0,
+    "commentCount": 0,
+    "playbackUrl": null
+  },
+  "upload": {
+    "uploadUrl": "https://storage.googleapis.com/...",
+    "storagePath": "videos/userId123/videoId123/original.mp4",
+    "expiresAt": "2026-04-29T01:00:00.000Z"
+  }
+}
+```
+
+Upload the video file with `PUT` to `upload.uploadUrl` using the same `Content-Type` as `mimeType`.
+
+### ➡️ PATCH `/videos/:videoId/complete`
+Mark an uploaded video as ready after the Storage upload finishes.
+
+#### 📥 Request
+```json
+{
+  "durationMs": 18000,
+  "thumbnailUrl": "https://example.com/thumb.jpg"
+}
+```
+
+### ➡️ GET `/videos/feed?cursor=&limit=`
+Retrieve public ready videos ordered by newest first.
+
+#### 📤 Response
+```json
+{
+  "videos": [
+    {
+      "id": "videoId123",
+      "ownerId": "userId123",
+      "caption": "Study tip in 30 seconds",
+      "playbackUrl": "https://storage.googleapis.com/...",
+      "thumbnailUrl": "https://example.com/thumb.jpg",
+      "likeCount": 4,
+      "commentCount": 2,
+      "likedByMe": false,
+      "createdAt": "2026-04-29T01:00:00.000Z"
+    }
+  ],
+  "nextCursor": null
+}
+```
+
+### ➡️ GET `/videos/:videoId`
+Fetch a single video, including a short-lived playback URL and `likedByMe`.
+
+### ➡️ DELETE `/videos/:videoId`
+Delete a video owned by the authenticated user.
+
+### ➡️ POST `/videos/:videoId/like`
+Like a video. Safe to call multiple times.
+
+### ➡️ DELETE `/videos/:videoId/like`
+Unlike a video. Safe to call multiple times.
+
+### ➡️ GET `/videos/:videoId/comments?cursor=&limit=`
+Retrieve paginated comments for a video.
+
+### ➡️ POST `/videos/:videoId/comments`
+Create a comment.
+
+#### 📥 Request
+```json
+{
+  "text": "This helped a lot!"
+}
+```
+
+### ➡️ DELETE `/videos/:videoId/comments/:commentId`
+Delete a comment when the authenticated user is the comment author or video owner.
 
 ---
 
-## 📌 4. Submit Review for AI Feedback
+
+---
+
+## 📌 6. Submit Review for AI Feedback
 ### ➡️ POST `/review`
 Process user explanation of terms and get guided AI feedback.
 
@@ -306,7 +408,7 @@ Process user explanation of terms and get guided AI feedback.
 
 ---
 
-## 📌 5. Get AI Feedback Audio
+## 📌 7. Get AI Feedback Audio
 ### ➡️ GET `/review/audio?sessionId=abc123-session-id`
 Retrieve the TTS audio for the AI feedback associated with a previous review session.
 
@@ -334,5 +436,15 @@ Retrieve the TTS audio for the AI feedback associated with a previous review ses
 | PATCH  | `/friend-requests/:id` | Accept a friend request | ✅ Yes |
 | GET    | `/friends` | Get list of friends | ✅ Yes |
 | GET    | `/users/:userId` | Get user profile by ID | ✅ Yes |
+| POST   | `/videos` | Create video metadata and signed upload URL | ✅ Yes |
+| PATCH  | `/videos/:videoId/complete` | Mark an uploaded video as ready | ✅ Yes |
+| GET    | `/videos/feed` | Get public video feed | ✅ Yes |
+| GET    | `/videos/:videoId` | Get a video by ID | ✅ Yes |
+| DELETE | `/videos/:videoId` | Delete an owned video | ✅ Yes |
+| POST   | `/videos/:videoId/like` | Like a video | ✅ Yes |
+| DELETE | `/videos/:videoId/like` | Unlike a video | ✅ Yes |
+| GET    | `/videos/:videoId/comments` | Get video comments | ✅ Yes |
+| POST   | `/videos/:videoId/comments` | Create a video comment | ✅ Yes |
+| DELETE | `/videos/:videoId/comments/:commentId` | Delete a video comment | ✅ Yes |
 | POST   | `/review`                            | Submit transcript for review + feedback     | ✅ Yes |
 | GET    | `/review/audio?sessionId=...`        | Retrieve audio feedback (MP3)               | ✅ Yes |

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -2,6 +2,7 @@ import { FastifyRequest, FastifyReply } from "fastify";
 import { createFireStoreUser, deleteFireStoreUser, getUserProfile, updateFireStoreUser } from "../services/userService";
 import { checkStreakOnLogin } from "../services/streakService";
 import { updateFcmTokenForUser } from "../services/userService";
+import { getUserVideos } from "../services/videoService";
 
 interface CreateUserRequestBody {
   email: string;
@@ -134,5 +135,39 @@ export async function updateFcmTokenController(request: FastifyRequest, reply: F
   } catch (error) {
     console.error("Error updating FCM token:", error);
     reply.code(500).send({ error: "Failed to update FCM token" });
+  }
+}
+
+export async function getUserVideosController(
+  request: FastifyRequest,
+  reply: FastifyReply
+) {
+  try {
+    const user = (request as any).user;
+    if (!user || !user.uid) {
+      return reply.status(401).send({ error: "Unauthorized" });
+    }
+
+    const { userId } = request.params as { userId: string };
+    if (!userId) {
+      return reply.status(400).send({ error: "Missing userId parameter" });
+    }
+
+    const { cursor, limit } = request.query as {
+      cursor?: string;
+      limit?: string;
+    };
+
+    const result = await getUserVideos(userId, user.uid, {
+      cursor,
+      limit: limit ? Number(limit) : undefined,
+    });
+
+    return reply.status(200).send(result);
+  } catch (error) {
+    console.error("Error fetching user videos:", error);
+    const statusCode = typeof (error as any)?.statusCode === "number" ? (error as any).statusCode : 500;
+    const message = error instanceof Error ? error.message : "Failed to fetch user videos";
+    return reply.status(statusCode).send({ error: message });
   }
 }

--- a/src/controllers/videoController.ts
+++ b/src/controllers/videoController.ts
@@ -1,0 +1,216 @@
+import { FastifyReply, FastifyRequest } from "fastify";
+import {
+  completeVideoUpload,
+  createVideoComment,
+  createVideoUpload,
+  deleteVideo,
+  deleteVideoComment,
+  getVideoById,
+  getVideoComments,
+  getVideoFeed,
+  likeVideo,
+  unlikeVideo,
+  VideoVisibility,
+} from "../services/videoService";
+
+function getAuthenticatedUserId(request: FastifyRequest): string | null {
+  const user = (request as any).user;
+  return user?.uid || null;
+}
+
+function handleVideoError(reply: FastifyReply, error: unknown) {
+  const statusCode = typeof (error as any)?.statusCode === "number" ? (error as any).statusCode : 500;
+  const message = error instanceof Error ? error.message : "Internal Server Error";
+
+  console.error("Video controller error:", error);
+  return reply.status(statusCode).send({ error: message });
+}
+
+function parsePagination(query: { cursor?: string; limit?: string | number }) {
+  const limit = typeof query.limit === "string" ? Number(query.limit) : query.limit;
+  return {
+    cursor: query.cursor,
+    limit,
+  };
+}
+
+export async function createVideoController(request: FastifyRequest, reply: FastifyReply) {
+  try {
+    const userId = getAuthenticatedUserId(request);
+    if (!userId) {
+      return reply.status(401).send({ error: "Unauthorized" });
+    }
+
+    const { caption, mimeType, visibility } = request.body as {
+      caption?: string;
+      mimeType?: string;
+      visibility?: VideoVisibility;
+    };
+
+    if (!mimeType) {
+      return reply.status(400).send({ error: "Missing required field: mimeType" });
+    }
+
+    const result = await createVideoUpload(userId, {
+      caption,
+      mimeType,
+      visibility,
+    });
+
+    return reply.status(201).send(result);
+  } catch (error) {
+    return handleVideoError(reply, error);
+  }
+}
+
+export async function completeVideoUploadController(request: FastifyRequest, reply: FastifyReply) {
+  try {
+    const userId = getAuthenticatedUserId(request);
+    if (!userId) {
+      return reply.status(401).send({ error: "Unauthorized" });
+    }
+
+    const { videoId } = request.params as { videoId: string };
+    const { durationMs, thumbnailUrl } = request.body as {
+      durationMs?: number;
+      thumbnailUrl?: string;
+    };
+
+    const video = await completeVideoUpload(videoId, userId, {
+      durationMs,
+      thumbnailUrl,
+    });
+
+    return reply.status(200).send({ video });
+  } catch (error) {
+    return handleVideoError(reply, error);
+  }
+}
+
+export async function getVideoFeedController(request: FastifyRequest, reply: FastifyReply) {
+  try {
+    const userId = getAuthenticatedUserId(request);
+    if (!userId) {
+      return reply.status(401).send({ error: "Unauthorized" });
+    }
+
+    const result = await getVideoFeed(userId, parsePagination(request.query as { cursor?: string; limit?: string }));
+    return reply.status(200).send(result);
+  } catch (error) {
+    return handleVideoError(reply, error);
+  }
+}
+
+export async function getVideoByIdController(request: FastifyRequest, reply: FastifyReply) {
+  try {
+    const userId = getAuthenticatedUserId(request);
+    if (!userId) {
+      return reply.status(401).send({ error: "Unauthorized" });
+    }
+
+    const { videoId } = request.params as { videoId: string };
+    const video = await getVideoById(videoId, userId);
+    return reply.status(200).send({ video });
+  } catch (error) {
+    return handleVideoError(reply, error);
+  }
+}
+
+export async function deleteVideoController(request: FastifyRequest, reply: FastifyReply) {
+  try {
+    const userId = getAuthenticatedUserId(request);
+    if (!userId) {
+      return reply.status(401).send({ error: "Unauthorized" });
+    }
+
+    const { videoId } = request.params as { videoId: string };
+    await deleteVideo(videoId, userId);
+    return reply.status(200).send({ message: "Video deleted successfully" });
+  } catch (error) {
+    return handleVideoError(reply, error);
+  }
+}
+
+export async function likeVideoController(request: FastifyRequest, reply: FastifyReply) {
+  try {
+    const userId = getAuthenticatedUserId(request);
+    if (!userId) {
+      return reply.status(401).send({ error: "Unauthorized" });
+    }
+
+    const { videoId } = request.params as { videoId: string };
+    const result = await likeVideo(videoId, userId);
+    return reply.status(200).send(result);
+  } catch (error) {
+    return handleVideoError(reply, error);
+  }
+}
+
+export async function unlikeVideoController(request: FastifyRequest, reply: FastifyReply) {
+  try {
+    const userId = getAuthenticatedUserId(request);
+    if (!userId) {
+      return reply.status(401).send({ error: "Unauthorized" });
+    }
+
+    const { videoId } = request.params as { videoId: string };
+    const result = await unlikeVideo(videoId, userId);
+    return reply.status(200).send(result);
+  } catch (error) {
+    return handleVideoError(reply, error);
+  }
+}
+
+export async function getVideoCommentsController(request: FastifyRequest, reply: FastifyReply) {
+  try {
+    const userId = getAuthenticatedUserId(request);
+    if (!userId) {
+      return reply.status(401).send({ error: "Unauthorized" });
+    }
+
+    const { videoId } = request.params as { videoId: string };
+    const result = await getVideoComments(
+      videoId,
+      userId,
+      parsePagination(request.query as { cursor?: string; limit?: string })
+    );
+    return reply.status(200).send(result);
+  } catch (error) {
+    return handleVideoError(reply, error);
+  }
+}
+
+export async function createVideoCommentController(request: FastifyRequest, reply: FastifyReply) {
+  try {
+    const userId = getAuthenticatedUserId(request);
+    if (!userId) {
+      return reply.status(401).send({ error: "Unauthorized" });
+    }
+
+    const { videoId } = request.params as { videoId: string };
+    const { text } = request.body as { text?: string };
+    if (!text) {
+      return reply.status(400).send({ error: "Missing required field: text" });
+    }
+
+    const comment = await createVideoComment(videoId, userId, text);
+    return reply.status(201).send({ comment });
+  } catch (error) {
+    return handleVideoError(reply, error);
+  }
+}
+
+export async function deleteVideoCommentController(request: FastifyRequest, reply: FastifyReply) {
+  try {
+    const userId = getAuthenticatedUserId(request);
+    if (!userId) {
+      return reply.status(401).send({ error: "Unauthorized" });
+    }
+
+    const { videoId, commentId } = request.params as { videoId: string; commentId: string };
+    await deleteVideoComment(videoId, commentId, userId);
+    return reply.status(200).send({ message: "Comment deleted successfully" });
+  } catch (error) {
+    return handleVideoError(reply, error);
+  }
+}

--- a/src/controllers/videoController.ts
+++ b/src/controllers/videoController.ts
@@ -41,9 +41,11 @@ export async function createVideoController(request: FastifyRequest, reply: Fast
       return reply.status(401).send({ error: "Unauthorized" });
     }
 
-    const { caption, mimeType, visibility } = request.body as {
+    const { caption, mimeType, subject, thumbnailMimeType, visibility } = request.body as {
       caption?: string;
       mimeType?: string;
+      subject?: string;
+      thumbnailMimeType?: string;
       visibility?: VideoVisibility;
     };
 
@@ -54,6 +56,8 @@ export async function createVideoController(request: FastifyRequest, reply: Fast
     const result = await createVideoUpload(userId, {
       caption,
       mimeType,
+      subject,
+      thumbnailMimeType,
       visibility,
     });
 

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -1,5 +1,5 @@
 import { FastifyInstance } from "fastify";
-import { deleteUserController, ensureUserExistsController, getUserProfileController, updateUserProfileController } from "../controllers/userController";
+import { deleteUserController, ensureUserExistsController, getUserProfileController, getUserVideosController, updateUserProfileController } from "../controllers/userController";
 import { authenticateUser } from "../middleware/authUser";
 
 async function userRoutes(fastify: FastifyInstance) {
@@ -15,6 +15,13 @@ async function userRoutes(fastify: FastifyInstance) {
     url: "/users/:userId",
     preHandler: authenticateUser, // Ensures the request is authenticated.
     handler: getUserProfileController,
+  });
+
+  fastify.route({
+    method: "GET",
+    url: "/users/:userId/videos",
+    preHandler: authenticateUser,
+    handler: getUserVideosController,
   });
 
   fastify.route({

--- a/src/routes/videoRoutes.ts
+++ b/src/routes/videoRoutes.ts
@@ -1,0 +1,88 @@
+import { FastifyInstance } from "fastify";
+import {
+  completeVideoUploadController,
+  createVideoCommentController,
+  createVideoController,
+  deleteVideoCommentController,
+  deleteVideoController,
+  getVideoByIdController,
+  getVideoCommentsController,
+  getVideoFeedController,
+  likeVideoController,
+  unlikeVideoController,
+} from "../controllers/videoController";
+import { authenticateUser } from "../middleware/authUser";
+
+async function videoRoutes(fastify: FastifyInstance) {
+  fastify.route({
+    method: "POST",
+    url: "/videos",
+    preHandler: authenticateUser,
+    handler: createVideoController,
+  });
+
+  fastify.route({
+    method: "GET",
+    url: "/videos/feed",
+    preHandler: authenticateUser,
+    handler: getVideoFeedController,
+  });
+
+  fastify.route({
+    method: "GET",
+    url: "/videos/:videoId",
+    preHandler: authenticateUser,
+    handler: getVideoByIdController,
+  });
+
+  fastify.route({
+    method: "PATCH",
+    url: "/videos/:videoId/complete",
+    preHandler: authenticateUser,
+    handler: completeVideoUploadController,
+  });
+
+  fastify.route({
+    method: "DELETE",
+    url: "/videos/:videoId",
+    preHandler: authenticateUser,
+    handler: deleteVideoController,
+  });
+
+  fastify.route({
+    method: "POST",
+    url: "/videos/:videoId/like",
+    preHandler: authenticateUser,
+    handler: likeVideoController,
+  });
+
+  fastify.route({
+    method: "DELETE",
+    url: "/videos/:videoId/like",
+    preHandler: authenticateUser,
+    handler: unlikeVideoController,
+  });
+
+  fastify.route({
+    method: "GET",
+    url: "/videos/:videoId/comments",
+    preHandler: authenticateUser,
+    handler: getVideoCommentsController,
+  });
+
+  fastify.route({
+    method: "POST",
+    url: "/videos/:videoId/comments",
+    preHandler: authenticateUser,
+    handler: createVideoCommentController,
+  });
+
+  fastify.route({
+    method: "DELETE",
+    url: "/videos/:videoId/comments/:commentId",
+    preHandler: authenticateUser,
+    handler: deleteVideoCommentController,
+  });
+}
+
+export default videoRoutes;

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import ragRoutes from './routes/ragRoutes';
 import notiRoutes from './routes/notifRoutes';
 import cronRoutes from './routes/cronRoutes';
 import AASARoutes from './routes/AASARoutes';
+import videoRoutes from './routes/videoRoutes';
 
 
 const fastify = Fastify({ logger: true });
@@ -37,6 +38,7 @@ fastify.register(ragRoutes);
 fastify.register(notiRoutes)
 fastify.register(cronRoutes);
 fastify.register(AASARoutes);
+fastify.register(videoRoutes);
 
 // Health check route
 fastify.get("/", async () => {

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -29,6 +29,8 @@ export async function createFireStoreUser(uid: string, data: UserProfileData) {
           emailLower: data.email?.toLowerCase() || "",
           nameLower: data.name?.toLowerCase() || "",
           profilePicture: data.profilePicture || "default",
+          timezone: data.timezone || "",
+          hasCompletedOnboarding: data.hasCompletedOnboarding ?? false,
   
           // New fields for freemium control
           isPremium: false,

--- a/src/services/videoService.ts
+++ b/src/services/videoService.ts
@@ -1,0 +1,571 @@
+import { admin, db } from "../config/firebaseConfig";
+import {
+  buildVideoStoragePath,
+  createSignedVideoPlaybackUrl,
+  createSignedVideoUploadUrl,
+  deleteStoredVideo,
+  getStoredVideoMetadata,
+  SignedUploadTarget,
+} from "./videoStorageService";
+
+export type VideoVisibility = "public" | "friends" | "private";
+export type VideoStatus = "uploading" | "processing" | "ready" | "failed" | "deleted";
+
+export interface CreateVideoInput {
+  caption?: string;
+  mimeType: string;
+  visibility?: VideoVisibility;
+}
+
+export interface CompleteVideoUploadInput {
+  durationMs?: number;
+  thumbnailUrl?: string;
+}
+
+export interface VideoComment {
+  id: string;
+  authorId: string;
+  authorName: string;
+  authorProfilePicture: string;
+  text: string;
+  likeCount: number;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface VideoResponse {
+  id: string;
+  ownerId: string;
+  ownerName: string;
+  ownerProfilePicture: string;
+  caption: string;
+  storagePath: string;
+  playbackUrl: string | null;
+  thumbnailUrl: string | null;
+  mimeType: string;
+  sizeBytes: number | null;
+  durationMs: number | null;
+  status: VideoStatus;
+  visibility: VideoVisibility;
+  likeCount: number;
+  commentCount: number;
+  likedByMe: boolean;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+interface VideoDocument {
+  ownerId: string;
+  ownerName: string;
+  ownerProfilePicture: string;
+  caption: string;
+  storagePath: string;
+  playbackUrl: string | null;
+  thumbnailUrl: string | null;
+  mimeType: string;
+  sizeBytes: number | null;
+  durationMs: number | null;
+  status: VideoStatus;
+  visibility: VideoVisibility;
+  likeCount: number;
+  commentCount: number;
+  createdAt: FirebaseFirestore.FieldValue | FirebaseFirestore.Timestamp;
+  updatedAt: FirebaseFirestore.FieldValue | FirebaseFirestore.Timestamp;
+  deletedAt?: FirebaseFirestore.FieldValue | FirebaseFirestore.Timestamp;
+}
+
+class ServiceError extends Error {
+  statusCode: number;
+
+  constructor(statusCode: number, message: string) {
+    super(message);
+    this.statusCode = statusCode;
+  }
+}
+
+const VIDEOS_COLLECTION = "videos";
+const MAX_CAPTION_LENGTH = 2200;
+const MAX_COMMENT_LENGTH = 500;
+const DEFAULT_PAGE_LIMIT = 20;
+const MAX_PAGE_LIMIT = 50;
+
+function assertVideoMimeType(mimeType: string): void {
+  if (!mimeType || !mimeType.toLowerCase().startsWith("video/")) {
+    throw new ServiceError(400, "mimeType must be a video MIME type");
+  }
+}
+
+function normalizeVisibility(visibility?: VideoVisibility): VideoVisibility {
+  if (!visibility) return "public";
+  if (!["public", "friends", "private"].includes(visibility)) {
+    throw new ServiceError(400, "visibility must be public, friends, or private");
+  }
+  return visibility;
+}
+
+function normalizeCaption(caption?: string): string {
+  const normalized = (caption || "").trim();
+  if (normalized.length > MAX_CAPTION_LENGTH) {
+    throw new ServiceError(400, `caption must be ${MAX_CAPTION_LENGTH} characters or fewer`);
+  }
+  return normalized;
+}
+
+function normalizeComment(text: string): string {
+  const normalized = (text || "").trim();
+  if (!normalized) {
+    throw new ServiceError(400, "Comment text is required");
+  }
+  if (normalized.length > MAX_COMMENT_LENGTH) {
+    throw new ServiceError(400, `Comment text must be ${MAX_COMMENT_LENGTH} characters or fewer`);
+  }
+  return normalized;
+}
+
+function normalizeLimit(limit?: number): number {
+  if (!limit || Number.isNaN(limit)) return DEFAULT_PAGE_LIMIT;
+  return Math.min(Math.max(Math.floor(limit), 1), MAX_PAGE_LIMIT);
+}
+
+function serializeTimestamp(value: any): string | null {
+  if (!value) return null;
+  if (typeof value === "string") return value;
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value.toDate === "function") return value.toDate().toISOString();
+  return null;
+}
+
+function timestampToMillis(value: any): number {
+  if (!value) return 0;
+  if (typeof value.toMillis === "function") return value.toMillis();
+  if (typeof value.toDate === "function") return value.toDate().getTime();
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === "string") return new Date(value).getTime();
+  return 0;
+}
+
+function encodeCursor(createdAt: any, id: string): string {
+  return Buffer.from(
+    JSON.stringify({
+      createdAt: timestampToMillis(createdAt),
+      id,
+    })
+  ).toString("base64url");
+}
+
+function decodeCursor(cursor?: string): { createdAt: FirebaseFirestore.Timestamp; id: string } | null {
+  if (!cursor) return null;
+
+  try {
+    const decoded = JSON.parse(Buffer.from(cursor, "base64url").toString("utf8")) as {
+      createdAt?: number;
+      id?: string;
+    };
+
+    if (!decoded.createdAt || !decoded.id) {
+      throw new Error("Invalid cursor payload");
+    }
+
+    return {
+      createdAt: admin.firestore.Timestamp.fromMillis(decoded.createdAt),
+      id: decoded.id,
+    };
+  } catch {
+    throw new ServiceError(400, "Invalid cursor");
+  }
+}
+
+async function getUserSnapshot(userId: string): Promise<FirebaseFirestore.DocumentSnapshot> {
+  const userDoc = await db.collection("users").doc(userId).get();
+  if (!userDoc.exists) {
+    throw new ServiceError(404, "User not found");
+  }
+  return userDoc;
+}
+
+function canReadVideo(video: VideoDocument, viewerId: string): boolean {
+  if (video.status === "deleted") return false;
+  if (video.ownerId === viewerId) return true;
+  return video.status === "ready" && video.visibility === "public";
+}
+
+function canInteractWithVideo(video: VideoDocument, viewerId: string): boolean {
+  return video.status === "ready" && canReadVideo(video, viewerId);
+}
+
+async function serializeVideo(
+  doc: FirebaseFirestore.DocumentSnapshot,
+  viewerId: string
+): Promise<VideoResponse> {
+  const data = doc.data() as VideoDocument;
+  const likedByMe = (
+    await doc.ref.collection("likes").doc(viewerId).get()
+  ).exists;
+
+  const playbackUrl =
+    data.status === "ready" && data.storagePath
+      ? await createSignedVideoPlaybackUrl(data.storagePath)
+      : null;
+
+  return {
+    id: doc.id,
+    ownerId: data.ownerId,
+    ownerName: data.ownerName,
+    ownerProfilePicture: data.ownerProfilePicture,
+    caption: data.caption,
+    storagePath: data.storagePath,
+    playbackUrl,
+    thumbnailUrl: data.thumbnailUrl || null,
+    mimeType: data.mimeType,
+    sizeBytes: data.sizeBytes ?? null,
+    durationMs: data.durationMs ?? null,
+    status: data.status,
+    visibility: data.visibility,
+    likeCount: data.likeCount || 0,
+    commentCount: data.commentCount || 0,
+    likedByMe,
+    createdAt: serializeTimestamp(data.createdAt),
+    updatedAt: serializeTimestamp(data.updatedAt),
+  };
+}
+
+export async function createVideoUpload(
+  ownerId: string,
+  input: CreateVideoInput
+): Promise<{ video: VideoResponse; upload: SignedUploadTarget }> {
+  assertVideoMimeType(input.mimeType);
+
+  const userDoc = await getUserSnapshot(ownerId);
+  const userData = userDoc.data() || {};
+  const videoRef = db.collection(VIDEOS_COLLECTION).doc();
+  const storagePath = buildVideoStoragePath(ownerId, videoRef.id, input.mimeType);
+  const upload = await createSignedVideoUploadUrl(storagePath, input.mimeType);
+
+  const video: VideoDocument = {
+    ownerId,
+    ownerName: userData.name || "Unknown User",
+    ownerProfilePicture: userData.profilePicture || "default",
+    caption: normalizeCaption(input.caption),
+    storagePath,
+    playbackUrl: null,
+    thumbnailUrl: null,
+    mimeType: input.mimeType,
+    sizeBytes: null,
+    durationMs: null,
+    status: "uploading",
+    visibility: normalizeVisibility(input.visibility),
+    likeCount: 0,
+    commentCount: 0,
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  };
+
+  await videoRef.set(video);
+  const createdDoc = await videoRef.get();
+
+  return {
+    video: await serializeVideo(createdDoc, ownerId),
+    upload,
+  };
+}
+
+export async function completeVideoUpload(
+  videoId: string,
+  ownerId: string,
+  input: CompleteVideoUploadInput
+): Promise<VideoResponse> {
+  const videoRef = db.collection(VIDEOS_COLLECTION).doc(videoId);
+  const videoDoc = await videoRef.get();
+
+  if (!videoDoc.exists) {
+    throw new ServiceError(404, "Video not found");
+  }
+
+  const video = videoDoc.data() as VideoDocument;
+  if (video.ownerId !== ownerId) {
+    throw new ServiceError(403, "Only the owner can complete this upload");
+  }
+  if (video.status === "deleted") {
+    throw new ServiceError(404, "Video not found");
+  }
+
+  const storedMetadata = await getStoredVideoMetadata(video.storagePath);
+  if (!storedMetadata) {
+    throw new ServiceError(400, "Uploaded video file was not found in storage");
+  }
+
+  await videoRef.update({
+    status: "ready",
+    sizeBytes: storedMetadata.sizeBytes ?? video.sizeBytes ?? null,
+    mimeType: storedMetadata.contentType || video.mimeType,
+    durationMs: typeof input.durationMs === "number" ? input.durationMs : video.durationMs ?? null,
+    thumbnailUrl: input.thumbnailUrl || video.thumbnailUrl || null,
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+
+  return getVideoById(videoId, ownerId);
+}
+
+export async function getVideoById(videoId: string, viewerId: string): Promise<VideoResponse> {
+  const videoDoc = await db.collection(VIDEOS_COLLECTION).doc(videoId).get();
+
+  if (!videoDoc.exists) {
+    throw new ServiceError(404, "Video not found");
+  }
+
+  const video = videoDoc.data() as VideoDocument;
+  if (video.status === "deleted") {
+    throw new ServiceError(404, "Video not found");
+  }
+  if (!canReadVideo(video, viewerId)) {
+    throw new ServiceError(403, "You do not have access to this video");
+  }
+
+  return serializeVideo(videoDoc, viewerId);
+}
+
+export async function getVideoFeed(
+  viewerId: string,
+  options: { cursor?: string; limit?: number }
+): Promise<{ videos: VideoResponse[]; nextCursor: string | null }> {
+  const limit = normalizeLimit(options.limit);
+  const cursor = decodeCursor(options.cursor);
+  const documentId = admin.firestore.FieldPath.documentId();
+
+  let query: FirebaseFirestore.Query = db
+    .collection(VIDEOS_COLLECTION)
+    .where("status", "==", "ready")
+    .where("visibility", "==", "public")
+    .orderBy("createdAt", "desc")
+    .orderBy(documentId, "desc")
+    .limit(limit + 1);
+
+  if (cursor) {
+    query = query.startAfter(cursor.createdAt, cursor.id);
+  }
+
+  const snapshot = await query.get();
+  const docs = snapshot.docs.slice(0, limit);
+  const videos = await Promise.all(docs.map((doc) => serializeVideo(doc, viewerId)));
+  const hasNextPage = snapshot.docs.length > limit;
+  const lastDoc = docs[docs.length - 1];
+
+  return {
+    videos,
+    nextCursor: hasNextPage && lastDoc ? encodeCursor(lastDoc.get("createdAt"), lastDoc.id) : null,
+  };
+}
+
+export async function deleteVideo(videoId: string, ownerId: string): Promise<void> {
+  const videoRef = db.collection(VIDEOS_COLLECTION).doc(videoId);
+  const videoDoc = await videoRef.get();
+
+  if (!videoDoc.exists) {
+    throw new ServiceError(404, "Video not found");
+  }
+
+  const video = videoDoc.data() as VideoDocument;
+  if (video.ownerId !== ownerId) {
+    throw new ServiceError(403, "Only the owner can delete this video");
+  }
+
+  await videoRef.update({
+    status: "deleted",
+    visibility: "private",
+    deletedAt: admin.firestore.FieldValue.serverTimestamp(),
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+
+  await deleteStoredVideo(video.storagePath);
+}
+
+export async function likeVideo(videoId: string, userId: string): Promise<{ liked: boolean; likeCount: number }> {
+  const videoRef = db.collection(VIDEOS_COLLECTION).doc(videoId);
+  const likeRef = videoRef.collection("likes").doc(userId);
+
+  return db.runTransaction(async (transaction) => {
+    const videoDoc = await transaction.get(videoRef);
+    const likeDoc = await transaction.get(likeRef);
+
+    if (!videoDoc.exists) {
+      throw new ServiceError(404, "Video not found");
+    }
+
+    const video = videoDoc.data() as VideoDocument;
+    if (!canInteractWithVideo(video, userId)) {
+      throw new ServiceError(403, "You do not have access to this video");
+    }
+
+    const currentLikeCount = video.likeCount || 0;
+    if (likeDoc.exists) {
+      return { liked: true, likeCount: currentLikeCount };
+    }
+
+    transaction.set(likeRef, {
+      userId,
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+    transaction.update(videoRef, {
+      likeCount: admin.firestore.FieldValue.increment(1),
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+
+    return { liked: true, likeCount: currentLikeCount + 1 };
+  });
+}
+
+export async function unlikeVideo(videoId: string, userId: string): Promise<{ liked: boolean; likeCount: number }> {
+  const videoRef = db.collection(VIDEOS_COLLECTION).doc(videoId);
+  const likeRef = videoRef.collection("likes").doc(userId);
+
+  return db.runTransaction(async (transaction) => {
+    const videoDoc = await transaction.get(videoRef);
+    const likeDoc = await transaction.get(likeRef);
+
+    if (!videoDoc.exists) {
+      throw new ServiceError(404, "Video not found");
+    }
+
+    const video = videoDoc.data() as VideoDocument;
+    if (!canInteractWithVideo(video, userId)) {
+      throw new ServiceError(403, "You do not have access to this video");
+    }
+
+    const currentLikeCount = video.likeCount || 0;
+    if (!likeDoc.exists) {
+      return { liked: false, likeCount: currentLikeCount };
+    }
+
+    transaction.delete(likeRef);
+    transaction.update(videoRef, {
+      likeCount: admin.firestore.FieldValue.increment(-1),
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+
+    return { liked: false, likeCount: Math.max(currentLikeCount - 1, 0) };
+  });
+}
+
+export async function createVideoComment(
+  videoId: string,
+  authorId: string,
+  text: string
+): Promise<VideoComment> {
+  const normalizedText = normalizeComment(text);
+  const userDoc = await getUserSnapshot(authorId);
+  const userData = userDoc.data() || {};
+  const videoRef = db.collection(VIDEOS_COLLECTION).doc(videoId);
+  const commentRef = videoRef.collection("comments").doc();
+
+  await db.runTransaction(async (transaction) => {
+    const videoDoc = await transaction.get(videoRef);
+
+    if (!videoDoc.exists) {
+      throw new ServiceError(404, "Video not found");
+    }
+
+    const video = videoDoc.data() as VideoDocument;
+    if (!canInteractWithVideo(video, authorId)) {
+      throw new ServiceError(403, "You do not have access to this video");
+    }
+
+    transaction.set(commentRef, {
+      authorId,
+      authorName: userData.name || "Unknown User",
+      authorProfilePicture: userData.profilePicture || "default",
+      text: normalizedText,
+      likeCount: 0,
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+    transaction.update(videoRef, {
+      commentCount: admin.firestore.FieldValue.increment(1),
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+  });
+
+  const createdComment = await commentRef.get();
+  return serializeComment(createdComment);
+}
+
+function serializeComment(doc: FirebaseFirestore.DocumentSnapshot): VideoComment {
+  const data = doc.data() || {};
+  return {
+    id: doc.id,
+    authorId: data.authorId,
+    authorName: data.authorName,
+    authorProfilePicture: data.authorProfilePicture,
+    text: data.text,
+    likeCount: data.likeCount || 0,
+    createdAt: serializeTimestamp(data.createdAt),
+    updatedAt: serializeTimestamp(data.updatedAt),
+  };
+}
+
+export async function getVideoComments(
+  videoId: string,
+  viewerId: string,
+  options: { cursor?: string; limit?: number }
+): Promise<{ comments: VideoComment[]; nextCursor: string | null }> {
+  await getVideoById(videoId, viewerId);
+
+  const limit = normalizeLimit(options.limit);
+  const cursor = decodeCursor(options.cursor);
+  const documentId = admin.firestore.FieldPath.documentId();
+
+  let query: FirebaseFirestore.Query = db
+    .collection(VIDEOS_COLLECTION)
+    .doc(videoId)
+    .collection("comments")
+    .orderBy("createdAt", "desc")
+    .orderBy(documentId, "desc")
+    .limit(limit + 1);
+
+  if (cursor) {
+    query = query.startAfter(cursor.createdAt, cursor.id);
+  }
+
+  const snapshot = await query.get();
+  const docs = snapshot.docs.slice(0, limit);
+  const comments = docs.map(serializeComment);
+  const hasNextPage = snapshot.docs.length > limit;
+  const lastDoc = docs[docs.length - 1];
+
+  return {
+    comments,
+    nextCursor: hasNextPage && lastDoc ? encodeCursor(lastDoc.get("createdAt"), lastDoc.id) : null,
+  };
+}
+
+export async function deleteVideoComment(
+  videoId: string,
+  commentId: string,
+  userId: string
+): Promise<void> {
+  const videoRef = db.collection(VIDEOS_COLLECTION).doc(videoId);
+  const commentRef = videoRef.collection("comments").doc(commentId);
+
+  await db.runTransaction(async (transaction) => {
+    const videoDoc = await transaction.get(videoRef);
+    const commentDoc = await transaction.get(commentRef);
+
+    if (!videoDoc.exists) {
+      throw new ServiceError(404, "Video not found");
+    }
+    if (!commentDoc.exists) {
+      throw new ServiceError(404, "Comment not found");
+    }
+
+    const video = videoDoc.data() as VideoDocument;
+    const comment = commentDoc.data() || {};
+    if (comment.authorId !== userId && video.ownerId !== userId) {
+      throw new ServiceError(403, "Only the comment author or video owner can delete this comment");
+    }
+
+    transaction.delete(commentRef);
+    transaction.update(videoRef, {
+      commentCount: admin.firestore.FieldValue.increment(-1),
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+  });
+}

--- a/src/services/videoService.ts
+++ b/src/services/videoService.ts
@@ -1,7 +1,10 @@
 import { admin, db } from "../config/firebaseConfig";
 import {
+  buildVideoThumbnailStoragePath,
   buildVideoStoragePath,
+  createSignedStorageReadUrl,
   createSignedVideoPlaybackUrl,
+  createSignedVideoThumbnailUploadUrl,
   createSignedVideoUploadUrl,
   deleteStoredVideo,
   getStoredVideoMetadata,
@@ -14,6 +17,8 @@ export type VideoStatus = "uploading" | "processing" | "ready" | "failed" | "del
 export interface CreateVideoInput {
   caption?: string;
   mimeType: string;
+  subject?: string;
+  thumbnailMimeType?: string;
   visibility?: VideoVisibility;
 }
 
@@ -39,9 +44,11 @@ export interface VideoResponse {
   ownerName: string;
   ownerProfilePicture: string;
   caption: string;
+  subject: string;
   storagePath: string;
   playbackUrl: string | null;
   thumbnailUrl: string | null;
+  thumbnailStoragePath: string | null;
   mimeType: string;
   sizeBytes: number | null;
   durationMs: number | null;
@@ -59,9 +66,11 @@ interface VideoDocument {
   ownerName: string;
   ownerProfilePicture: string;
   caption: string;
+  subject: string;
   storagePath: string;
   playbackUrl: string | null;
   thumbnailUrl: string | null;
+  thumbnailStoragePath: string | null;
   mimeType: string;
   sizeBytes: number | null;
   durationMs: number | null;
@@ -85,6 +94,7 @@ class ServiceError extends Error {
 
 const VIDEOS_COLLECTION = "videos";
 const MAX_CAPTION_LENGTH = 2200;
+const MAX_SUBJECT_LENGTH = 120;
 const MAX_COMMENT_LENGTH = 500;
 const DEFAULT_PAGE_LIMIT = 20;
 const MAX_PAGE_LIMIT = 50;
@@ -92,6 +102,13 @@ const MAX_PAGE_LIMIT = 50;
 function assertVideoMimeType(mimeType: string): void {
   if (!mimeType || !mimeType.toLowerCase().startsWith("video/")) {
     throw new ServiceError(400, "mimeType must be a video MIME type");
+  }
+}
+
+function assertThumbnailMimeType(mimeType?: string): void {
+  if (!mimeType) return;
+  if (!mimeType.toLowerCase().startsWith("image/")) {
+    throw new ServiceError(400, "thumbnailMimeType must be an image MIME type");
   }
 }
 
@@ -107,6 +124,14 @@ function normalizeCaption(caption?: string): string {
   const normalized = (caption || "").trim();
   if (normalized.length > MAX_CAPTION_LENGTH) {
     throw new ServiceError(400, `caption must be ${MAX_CAPTION_LENGTH} characters or fewer`);
+  }
+  return normalized;
+}
+
+function normalizeSubject(subject?: string): string {
+  const normalized = (subject || "").trim();
+  if (normalized.length > MAX_SUBJECT_LENGTH) {
+    throw new ServiceError(400, `subject must be ${MAX_SUBJECT_LENGTH} characters or fewer`);
   }
   return normalized;
 }
@@ -207,15 +232,22 @@ async function serializeVideo(
       ? await createSignedVideoPlaybackUrl(data.storagePath)
       : null;
 
+  const thumbnailUrl =
+    data.status === "ready" && data.thumbnailStoragePath
+      ? await createSignedStorageReadUrl(data.thumbnailStoragePath)
+      : data.thumbnailUrl || null;
+
   return {
     id: doc.id,
     ownerId: data.ownerId,
     ownerName: data.ownerName,
     ownerProfilePicture: data.ownerProfilePicture,
     caption: data.caption,
+    subject: data.subject || "",
     storagePath: data.storagePath,
     playbackUrl,
-    thumbnailUrl: data.thumbnailUrl || null,
+    thumbnailUrl,
+    thumbnailStoragePath: data.thumbnailStoragePath || null,
     mimeType: data.mimeType,
     sizeBytes: data.sizeBytes ?? null,
     durationMs: data.durationMs ?? null,
@@ -232,23 +264,33 @@ async function serializeVideo(
 export async function createVideoUpload(
   ownerId: string,
   input: CreateVideoInput
-): Promise<{ video: VideoResponse; upload: SignedUploadTarget }> {
+): Promise<{ video: VideoResponse; upload: SignedUploadTarget; thumbnailUpload: SignedUploadTarget | null }> {
   assertVideoMimeType(input.mimeType);
+  assertThumbnailMimeType(input.thumbnailMimeType);
 
   const userDoc = await getUserSnapshot(ownerId);
   const userData = userDoc.data() || {};
   const videoRef = db.collection(VIDEOS_COLLECTION).doc();
   const storagePath = buildVideoStoragePath(ownerId, videoRef.id, input.mimeType);
   const upload = await createSignedVideoUploadUrl(storagePath, input.mimeType);
+  const thumbnailStoragePath = input.thumbnailMimeType
+    ? buildVideoThumbnailStoragePath(ownerId, videoRef.id, input.thumbnailMimeType)
+    : null;
+  const thumbnailUpload =
+    input.thumbnailMimeType && thumbnailStoragePath
+      ? await createSignedVideoThumbnailUploadUrl(thumbnailStoragePath, input.thumbnailMimeType)
+      : null;
 
   const video: VideoDocument = {
     ownerId,
     ownerName: userData.name || "Unknown User",
     ownerProfilePicture: userData.profilePicture || "default",
     caption: normalizeCaption(input.caption),
+    subject: normalizeSubject(input.subject),
     storagePath,
     playbackUrl: null,
     thumbnailUrl: null,
+    thumbnailStoragePath,
     mimeType: input.mimeType,
     sizeBytes: null,
     durationMs: null,
@@ -266,6 +308,7 @@ export async function createVideoUpload(
   return {
     video: await serializeVideo(createdDoc, ownerId),
     upload,
+    thumbnailUpload,
   };
 }
 
@@ -294,12 +337,19 @@ export async function completeVideoUpload(
     throw new ServiceError(400, "Uploaded video file was not found in storage");
   }
 
+  if (video.thumbnailStoragePath) {
+    const storedThumbnailMetadata = await getStoredVideoMetadata(video.thumbnailStoragePath);
+    if (!storedThumbnailMetadata) {
+      throw new ServiceError(400, "Uploaded thumbnail file was not found in storage");
+    }
+  }
+
   await videoRef.update({
     status: "ready",
     sizeBytes: storedMetadata.sizeBytes ?? video.sizeBytes ?? null,
     mimeType: storedMetadata.contentType || video.mimeType,
     durationMs: typeof input.durationMs === "number" ? input.durationMs : video.durationMs ?? null,
-    thumbnailUrl: input.thumbnailUrl || video.thumbnailUrl || null,
+    thumbnailUrl: video.thumbnailStoragePath ? null : input.thumbnailUrl || video.thumbnailUrl || null,
     updatedAt: admin.firestore.FieldValue.serverTimestamp(),
   });
 
@@ -417,6 +467,9 @@ export async function deleteVideo(videoId: string, ownerId: string): Promise<voi
   });
 
   await deleteStoredVideo(video.storagePath);
+  if (video.thumbnailStoragePath) {
+    await deleteStoredVideo(video.thumbnailStoragePath);
+  }
 }
 
 export async function likeVideo(videoId: string, userId: string): Promise<{ liked: boolean; likeCount: number }> {

--- a/src/services/videoService.ts
+++ b/src/services/videoService.ts
@@ -356,6 +356,46 @@ export async function getVideoFeed(
   };
 }
 
+export async function getUserVideos(
+  profileUserId: string,
+  viewerId: string,
+  options: { cursor?: string; limit?: number }
+): Promise<{ videos: VideoResponse[]; nextCursor: string | null }> {
+  const limit = normalizeLimit(options.limit);
+  const cursor = decodeCursor(options.cursor);
+  const documentId = admin.firestore.FieldPath.documentId();
+  const isOwner = profileUserId === viewerId;
+
+  let query: FirebaseFirestore.Query = db
+    .collection(VIDEOS_COLLECTION)
+    .where("ownerId", "==", profileUserId)
+    .where("status", "==", "ready");
+
+  if (!isOwner) {
+    query = query.where("visibility", "==", "public");
+  }
+
+  query = query
+    .orderBy("createdAt", "desc")
+    .orderBy(documentId, "desc")
+    .limit(limit + 1);
+
+  if (cursor) {
+    query = query.startAfter(cursor.createdAt, cursor.id);
+  }
+
+  const snapshot = await query.get();
+  const docs = snapshot.docs.slice(0, limit);
+  const videos = await Promise.all(docs.map((doc) => serializeVideo(doc, viewerId)));
+  const hasNextPage = snapshot.docs.length > limit;
+  const lastDoc = docs[docs.length - 1];
+
+  return {
+    videos,
+    nextCursor: hasNextPage && lastDoc ? encodeCursor(lastDoc.get("createdAt"), lastDoc.id) : null,
+  };
+}
+
 export async function deleteVideo(videoId: string, ownerId: string): Promise<void> {
   const videoRef = db.collection(VIDEOS_COLLECTION).doc(videoId);
   const videoDoc = await videoRef.get();

--- a/src/services/videoStorageService.ts
+++ b/src/services/videoStorageService.ts
@@ -27,7 +27,12 @@ export function buildVideoStoragePath(userId: string, videoId: string, mimeType:
   return `videos/${userId}/${videoId}/original.${extension}`;
 }
 
-export async function createSignedVideoUploadUrl(
+export function buildVideoThumbnailStoragePath(userId: string, videoId: string, mimeType: string): string {
+  const extension = getExtensionFromMimeType(mimeType);
+  return `videos/${userId}/${videoId}/thumbnail.${extension}`;
+}
+
+export async function createSignedStorageUploadUrl(
   storagePath: string,
   mimeType: string,
   ttlMs: number = DEFAULT_UPLOAD_URL_TTL_MS
@@ -50,7 +55,23 @@ export async function createSignedVideoUploadUrl(
   };
 }
 
-export async function createSignedVideoPlaybackUrl(
+export async function createSignedVideoUploadUrl(
+  storagePath: string,
+  mimeType: string,
+  ttlMs: number = DEFAULT_UPLOAD_URL_TTL_MS
+): Promise<SignedUploadTarget> {
+  return createSignedStorageUploadUrl(storagePath, mimeType, ttlMs);
+}
+
+export async function createSignedVideoThumbnailUploadUrl(
+  storagePath: string,
+  mimeType: string,
+  ttlMs: number = DEFAULT_UPLOAD_URL_TTL_MS
+): Promise<SignedUploadTarget> {
+  return createSignedStorageUploadUrl(storagePath, mimeType, ttlMs);
+}
+
+export async function createSignedStorageReadUrl(
   storagePath: string,
   ttlMs: number = DEFAULT_PLAYBACK_URL_TTL_MS
 ): Promise<string> {
@@ -63,6 +84,13 @@ export async function createSignedVideoPlaybackUrl(
   });
 
   return playbackUrl;
+}
+
+export async function createSignedVideoPlaybackUrl(
+  storagePath: string,
+  ttlMs: number = DEFAULT_PLAYBACK_URL_TTL_MS
+): Promise<string> {
+  return createSignedStorageReadUrl(storagePath, ttlMs);
 }
 
 export async function getStoredVideoMetadata(storagePath: string): Promise<StoredVideoMetadata | null> {

--- a/src/services/videoStorageService.ts
+++ b/src/services/videoStorageService.ts
@@ -1,0 +1,91 @@
+import { storage } from "../config/firebaseConfig";
+
+const DEFAULT_UPLOAD_URL_TTL_MS = 15 * 60 * 1000;
+const DEFAULT_PLAYBACK_URL_TTL_MS = 60 * 60 * 1000;
+
+export interface SignedUploadTarget {
+  uploadUrl: string;
+  storagePath: string;
+  expiresAt: string;
+}
+
+export interface StoredVideoMetadata {
+  sizeBytes?: number;
+  contentType?: string;
+}
+
+function getExtensionFromMimeType(mimeType: string): string {
+  const subtype = mimeType.split("/")[1]?.split(";")[0]?.trim().toLowerCase();
+  if (!subtype) return "mp4";
+
+  const normalized = subtype === "quicktime" ? "mov" : subtype;
+  return normalized.replace(/[^a-z0-9]/g, "") || "mp4";
+}
+
+export function buildVideoStoragePath(userId: string, videoId: string, mimeType: string): string {
+  const extension = getExtensionFromMimeType(mimeType);
+  return `videos/${userId}/${videoId}/original.${extension}`;
+}
+
+export async function createSignedVideoUploadUrl(
+  storagePath: string,
+  mimeType: string,
+  ttlMs: number = DEFAULT_UPLOAD_URL_TTL_MS
+): Promise<SignedUploadTarget> {
+  const bucket = storage.bucket();
+  const file = bucket.file(storagePath);
+  const expiresAtMs = Date.now() + ttlMs;
+
+  const [uploadUrl] = await file.getSignedUrl({
+    version: "v4",
+    action: "write",
+    expires: expiresAtMs,
+    contentType: mimeType,
+  });
+
+  return {
+    uploadUrl,
+    storagePath,
+    expiresAt: new Date(expiresAtMs).toISOString(),
+  };
+}
+
+export async function createSignedVideoPlaybackUrl(
+  storagePath: string,
+  ttlMs: number = DEFAULT_PLAYBACK_URL_TTL_MS
+): Promise<string> {
+  const bucket = storage.bucket();
+  const file = bucket.file(storagePath);
+  const [playbackUrl] = await file.getSignedUrl({
+    version: "v4",
+    action: "read",
+    expires: Date.now() + ttlMs,
+  });
+
+  return playbackUrl;
+}
+
+export async function getStoredVideoMetadata(storagePath: string): Promise<StoredVideoMetadata | null> {
+  const bucket = storage.bucket();
+  const file = bucket.file(storagePath);
+  const [exists] = await file.exists();
+
+  if (!exists) {
+    return null;
+  }
+
+  const [metadata] = await file.getMetadata();
+  const sizeBytes = metadata.size ? Number(metadata.size) : undefined;
+
+  return {
+    sizeBytes: Number.isFinite(sizeBytes) ? sizeBytes : undefined,
+    contentType: metadata.contentType,
+  };
+}
+
+export async function deleteStoredVideo(storagePath: string): Promise<void> {
+  const bucket = storage.bucket();
+  const file = bucket.file(storagePath);
+
+  await file.delete({ ignoreNotFound: true });
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new set of authenticated video CRUD/feed endpoints backed by Firestore + Firebase Storage signed URLs and transactional like/comment counters, which may impact data integrity and access control if misconfigured.
> 
> **Overview**
> **Adds a short-video feature set** with new authenticated routes for creating videos via direct-to-Firebase Storage signed uploads, completing uploads, fetching a public feed and individual videos (with short-lived playback URLs), deleting owned videos, and managing likes/comments.
> 
> Implements new `videoService`/`videoStorageService` to store video metadata in Firestore, generate signed upload/read URLs, enforce basic visibility/ownership rules, and support cursor-based pagination. Also adds `GET /users/:userId/videos` for per-user video lists and extends user creation to persist `timezone` and `hasCompletedOnboarding` fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 125f0c4cf4f95cb4c473a7095225ebbebf3f6c67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->